### PR TITLE
Added ignore files for tinymce in gitignore while using pnpm. Need to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Package managers file
+pnpm-lock.yaml
+
 # environment variables
 .env
 .env.production
@@ -25,3 +28,5 @@ pnpm-debug.log*
 
 # TinyMCE self-hosted gets copied on build, so no need to commit.
 public/tinymce/
+# Ignore all versions of tinymce in the specified path
+node_modules/.pnpm/tinymce@*/node_modules/tinymce

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -10,6 +10,8 @@ async function cpPkg(sourceDir: string, destDir: string) {
   // Ensure the public directory exists
   if (!fs.existsSync(path.dirname(destinationPath))) {
     fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  } else {
+    return "";
   }
 
   // Copy entire directory from node_modules to public directory


### PR DESCRIPTION
Hi.

![image](https://github.com/user-attachments/assets/4d5ea61b-a3c1-4bfd-9185-ff4d5e48471e)


Problems: 
 - When using pnpm as a package manager, it will create a pnpm-lock.yml file that can be heavy and not useful if you are using another package manager.
- Tinymce : when installing with pnpm, it will create a folder in public/tinymce and  it does it. But, when you start again the application with "pnpm dev" it will try to create this folder again, as the folder already exists, it creates a problem.

![image](https://github.com/user-attachments/assets/b9e4ac23-783b-4a74-b8ac-822e53679c8e)


Solutions: 
 - add pnpm-lock.yaml in the .gitignore
 - add all version of tinymce in the .gitignore as pnpm seems to make a link into the node_modules instead of making a real copy of the folder
 - add a return value in the src/integrations.ts file, in the cpPkg if the folder exists, to not create it again.
![image](https://github.com/user-attachments/assets/53053b9a-18bb-4521-86af-3791a8440949)

