### PR TITLE
Update README and index.astro with Turso links and tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A modern, type-safe web development stack using Astro, TypeScript, HTMX, Alpine.js, and more.
 
+> [!TIP] 💡
+> [Turso](https://tur.so/freedomstack) has a generous free tier for database hosting and management. And, when it's time to scale, use the code `FREEDOMSTACK` for a discount on paid plans.
+
 ## Get Started 🚀
 
 ### 1. Create Your Project
@@ -75,7 +78,7 @@ If you want to learn more about Alpine.js, I recommend [Learn Alpine.js on codec
 
 ### The Database Layer
 
-If you want to learn more about the database layer, I recommend learning from [High Performance SQLite course](https://highperformancesqlite.com/), sponsored by [Turso](https://turso.tech/).
+If you want to learn more about the database layer, I recommend learning from [High Performance SQLite course](https://highperformancesqlite.com/), sponsored by [Turso](https://tur.so/freedomstack/).
 
 ### The Philosophy Layer
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,7 +40,7 @@ const faqItems = [
   {
     question: "How can I learn more about the libSQL database layer?",
     answer:
-      "If you want to learn more about the database layer, I recommend learning from [High Performance SQLite course](https://highperformancesqlite.com/), sponsored by [Turso](https://turso.tech/)."
+      "If you want to learn more about the database layer, I recommend learning from [High Performance SQLite course](https://highperformancesqlite.com/), sponsored by [Turso](https://tur.so/freedomstack)."
   },
   {
     question: "How can I learn more about Better Auth?",


### PR DESCRIPTION
- Added a tip about Turso's free tier and discount code in README.md.
- Updated the Turso link in the FAQ section of index.astro to match the new URL format.

These changes enhance the documentation and provide clearer guidance for users regarding database hosting options.