### PR TITLE
Enhance index.astro with new external links and titles for better A11y

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,7 +170,7 @@ Astro.response.headers.set("netlify-cache-tag", "components");
             @apply h-12 w-auto grayscale hover:grayscale-0 transition-all opacity-60 hover:opacity-100;
           }
         </style>
-        <a href="https://www.uneed.best/tool/freedom-stack---starter-kit" target="_blank">
+        <a title="Uneed" href="https://www.uneed.best/tool/freedom-stack---starter-kit" target="_blank">
           <svg
             style={{ aspectRatio: "800 / 220" }}
             viewBox="0 0 800 220"
@@ -210,6 +210,7 @@ Astro.response.headers.set("netlify-cache-tag", "components");
           href="https://faith.tools/app/1059-freedom-stack-full-stack-web-app-starter-kit"
           target="_blank"
           style={{ aspectRatio: "942 / 116" }}
+          title="faith.tools"
         >
           <svg
             class="max-h-10"
@@ -239,6 +240,7 @@ Astro.response.headers.set("netlify-cache-tag", "components");
           style={{ aspectRatio: "405 / 71" }}
           href="https://startupfa.me/s/freedom-stack?ref=freedom.faith.tools"
           target="_blank"
+          title="Startup Fame"
         >
           <img
             style={{ aspectRatio: "405 / 71" }}
@@ -250,6 +252,7 @@ Astro.response.headers.set("netlify-cache-tag", "components");
         <a
           href="https://astro.build/blog/whats-new-november-2024/?utm_source=withastro&utm_medium=email&utm_campaign=the-astro-post-november-2024"
           target="_blank"
+          title="Astro Blog"
         >
           <svg
             class="!h-16"
@@ -279,6 +282,20 @@ Astro.response.headers.set("netlify-cache-tag", "components");
             <path
               d="M404.808 76.4754C404.808 84.7795 398.81 88.6649 389.363 88.6649C379.991 88.6649 373.993 85.008 373.993 76.4754C373.993 67.9428 380.066 64.7431 389.363 64.7431C398.735 64.7431 404.808 68.1714 404.808 76.4754ZM420.478 76.0945C420.478 59.5626 407.582 52.1728 389.363 52.1728C371.069 52.1728 358.622 59.5626 358.622 76.0945C358.622 92.5503 370.244 101.388 389.288 101.388C408.482 101.388 420.478 92.5503 420.478 76.0945Z"
               fill="#17191E"></path>
+          </svg>
+        </a>
+
+        <a title="SaaS Boilerplates" href="https://saasboilerplates.dev/tools/freedomstack/" target="_blank">
+          <svg class="!h-16" viewBox="0 0 60 62" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M32.9219 8.84226C32.9219 5.86885 36.5379 4.40339 38.608 6.53787L57.6821 26.2056C58.9383 27.5009 59.6408 29.2344 59.6408 31.0388V53.8041C59.6408 56.7775 56.0248 58.243 53.9547 56.1085L34.8806 36.4407C33.6244 35.1454 32.9219 33.4119 32.9219 31.6075V8.84226Z"
+              fill="#737373"></path>
+            <path
+              d="M16.3633 8.19578C16.3633 5.22237 19.9793 3.75691 22.0494 5.89139L40.842 25.2689C42.2788 26.7503 43.0823 28.733 43.0823 30.7967V53.1576C43.0823 56.131 39.4662 57.5965 37.3961 55.462L18.322 35.7942C17.0658 34.4989 16.3633 32.7654 16.3633 30.9611V8.19578Z"
+              fill="#8F8F8F"></path>
+            <path
+              d="M0.359375 8.84226C0.359375 5.86885 3.97542 4.40339 6.04548 6.53787L25.1196 26.2056C26.3758 27.5009 27.0783 29.2344 27.0783 31.0388V53.8041C27.0783 56.7775 23.4623 58.243 21.3922 56.1085L2.3181 36.4407C1.06191 35.1454 0.359375 33.4119 0.359375 31.6075V8.84226Z"
+              fill="#ABABAB"></path>
           </svg>
         </a>
       </div>


### PR DESCRIPTION
- Added title attributes to existing external links for improved accessibility and user experience.
- Introduced a new link to "SaaS Boilerplates" with an accompanying SVG icon to enrich the resources section.
- Updated existing links to include descriptive titles for "Uneed," "faith.tools," "Startup Fame," and "Astro Blog," enhancing clarity for users.